### PR TITLE
Upgraded lodash due to vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/mapbox/eslint-plugin-script-tags#readme",
   "dependencies": {
     "execall": "^1.0.0",
-    "lodash": "^4.16.0",
+    "lodash": "^4.17.15",
     "split-lines": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Versions of lodash before 4.17.12 are vulnerable to Prototype Pollution. The function defaultsDeep allows a malicious user to modify the prototype of Object via {constructor: {prototype: {...}}} causing the addition or modification of an existing property that will exist on all objects.