### PR TITLE
Add support for Liquid templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,5 +14,6 @@ module.exports = {
     '.php': processor,
     '.vue': processor,
     '.erb': processor,
+    '.liquid': processor,
   },
 };


### PR DESCRIPTION
[Liquid](https://shopify.github.io/liquid/) is used for writing Shopify themes.