### PR TITLE
Skip script tags that don't include JS code

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -7,6 +7,7 @@ const reindent = require('./reindent');
 
 const sourceToLineMap = new Map();
 const snippetRegexp = /(<script[\s\S]*?>)([\s\S]*?)<\/\s*?script>/g;
+const typeAttrRegexp = /type=['"](.*)['"]/;
 
 function preprocess(code, filepath) {
   const sourceMap = new Map();
@@ -18,6 +19,12 @@ function preprocess(code, filepath) {
 
     let currentExtractedCodeLine = 0;
     const openingTag = match.subMatches[0];
+    const typeAttrMatch = openingTag.match(typeAttrRegexp);
+
+    if (typeAttrMatch && typeAttrMatch[1] !== 'text/javascript') {
+      return [];
+    }
+
     const reindentData = reindent(match.subMatches[1]);
 
     chunkMap.set('indentColumns', reindentData.indentColumns);

--- a/test/fixtures/html.html
+++ b/test/fixtures/html.html
@@ -16,5 +16,27 @@
     var b = "b"</script>
 
   <script></script>
+
+  <script type="text/javascript">
+    var a = 'b';
+      var b = "b";
+  </script>
+
+  <script type='text/javascript'>
+    var a = 'b';
+      var b = "b";
+  </script>
+
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org/"
+    }
+  </script>
+
+  <script type='application/ld+json'>
+    {
+      "@context": "https://schema.org/",
+    }
+  </script>
 </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -50,6 +50,23 @@ test('html', async (assert) => {
   assert.deepEqual(messages[3].line, 16);
   assert.deepEqual(messages[3].column, 13);
 
+  assert.deepEqual(messages[4].ruleId, 'indent');
+  assert.deepEqual(messages[4].line, 22);
+  assert.deepEqual(messages[4].column, 5);
+  assert.deepEqual(messages[5].ruleId, 'quotes');
+  assert.deepEqual(messages[5].line, 22);
+  assert.deepEqual(messages[5].column, 15);
+
+  assert.deepEqual(messages[6].ruleId, 'indent');
+  assert.deepEqual(messages[6].line, 27);
+  assert.deepEqual(messages[6].column, 5);
+  assert.deepEqual(messages[7].ruleId, 'quotes');
+  assert.deepEqual(messages[7].line, 27);
+  assert.deepEqual(messages[7].column, 15);
+
+  // Assert that is does not report errors for ld+json scripts
+  assert.deepEqual(messages.length, 8);
+
   assert.end();
 });
 


### PR DESCRIPTION
Hi!

I've been playing a bit with this plugin as I was trying to set up ESLint to lint JS code in Liquid templates. One of the issues I had was that I've got a bunch of script tags with JSON LD data and, as it's just JSON and not JS, ESLint reports parser errors.

This PR makes sure that only code from script tags without any `type` attribute or with `type` attribute equal to `text/javascript` is processed and  passed to ESLint.

Instead of asserting number of reported messages it could assert that there are no messages that include `'Parsing error'`, but this way seems good enough.